### PR TITLE
Fixing the text encoding issue of file and folder names

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -59,3 +59,5 @@ split-folders==0.5.1
 openpyxl==3.1.0
 # getpass
 
+# fixing text encoding ------------------------
+ftfy==6.1.1


### PR DESCRIPTION
Created a function fix_text_encoding, which gets called in download_gdrive in the server_utils. This function causes that no encoding issues are occuring and the ä,ö,å,etc get displayed correctly. This resolves issue #147.
And the ftfy package is added to the requirements.txt. 